### PR TITLE
Explicitly check for undefined

### DIFF
--- a/src/jsonrpc-websocket.ts
+++ b/src/jsonrpc-websocket.ts
@@ -260,7 +260,7 @@ export class JsonRpcWebsocket {
 
         parameterNames.forEach(paramName => {
           const paramValue = request.params[paramName];
-          if (!paramValue) {
+          if (paramValue === undefined) {
             throw new Error(
               `Invalid parameters. Method '${request.method}' expects parameters [${parameterNames}], but got [${Object.keys(request.params)}]`
             );


### PR DESCRIPTION
In the current implementation it casts the paramValue to boolean, and thus fails on anything that is castable to boolean false.

Checking explicitly for undefined allows usage of values like `false`, `0` or `""`